### PR TITLE
doc: use symlink and release build

### DIFF
--- a/documentation/docfx_project/setup/index.md
+++ b/documentation/docfx_project/setup/index.md
@@ -150,7 +150,7 @@ aichallenge2023-sim
    export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
    export RCUTILS_COLORIZED_OUTPUT=1
    cd /aichallenge/aichallenge_ws
-   colcon build 
+   colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
    source install/setup.bash
    ros2 launch autoware_launch e2e_simulator.launch.xml vehicle_model:=golfcart sensor_model:=awsim_sensor_kit map_path:=/aichallenge/mapfile
    ```

--- a/documentation/docfx_project_en/setup/index.md
+++ b/documentation/docfx_project_en/setup/index.md
@@ -155,7 +155,7 @@ Please install the following.
    export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
    export RCUTILS_COLORIZED_OUTPUT=1
    cd /aichallenge/aichallenge_ws
-   colcon build 
+   colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
    source install/setup.bash
    cd /aichallenge
    ros2 launch autoware_launch e2e_simulator.launch.xml vehicle_model:=golfcart sensor_model:=awsim_sensor_kit map_path:=/aichallenge/mapfile


### PR DESCRIPTION
以下の変更を追加しました。
- installにsymbolic linkを貼るoptionの追加
- release buildに変更

https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/