### PR TITLE
fix: update aichallenge_scoring config params

### DIFF
--- a/autoware/aichallenge_ws/src/aichallenge_scoring/config/aichallenge_scoring.param.yaml
+++ b/autoware/aichallenge_ws/src/aichallenge_scoring/config/aichallenge_scoring.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    task1_start_distance: 10.0  # Distance of the start line for Task 1
-    task1_end_distance: 16.0    # Distance of the end line for Task 1+6m
-    task3_start_distance: 30.0  # Distance of the start line for Task 3
-    task3_end_distance: 150.0    # Distance of the end line for Task 3
+    task1_start_distance: 8.0  # Distance of the start line for Task 1
+    task1_end_distance: 11.0    # Distance of the end line for Task 1+3m
+    task3_start_distance: 28.8  # Distance of the start line for Task 3
+    task3_end_distance: 170.0    # Distance of the end line for Task 3


### PR DESCRIPTION
- Update the parameter values in the `aichallenge_scoring.param.yaml` file.
- These values specify the following:
    - Where Task 1 begins and ends.
    - Where Task 3 begins and ends.

```   
task1_start_distance: 8.0  # Distance of the start line for Task 1
task1_end_distance: 11.0    # Distance of the end line for Task 1+3m
task3_start_distance: 28.8  # Distance of the start line for Task 3
task3_end_distance: 170.0    # Distance of the end line for Task 3
```

Task 3 Start Position (`task3_start_distance`)
![Screenshot from 2023-06-22 07-34-35](https://github.com/AutomotiveAIChallenge/aichallenge2023-sim/assets/5180742/83cc6084-f853-43fb-9f40-09d6760cc951)

Task 3 End Position / GOAL Position (`task3_end_distance`)
![Screenshot from 2023-06-22 07-36-37](https://github.com/AutomotiveAIChallenge/aichallenge2023-sim/assets/5180742/eee5334d-e0b8-447f-b292-dce89be37ec4)


