### PR TITLE
feat(tier4_perception_launch): remove downsampling from clustering

### DIFF
--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_launch/autoware_launch/config/perception/object_recognition/detection/clustering/compare_map.param.yaml
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_launch/autoware_launch/config/perception/object_recognition/detection/clustering/compare_map.param.yaml
@@ -1,0 +1,3 @@
+/**:
+  ros__parameters:
+    distance_threshold: 0.5

--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_launch/autoware_launch/config/perception/object_recognition/detection/clustering/euclidean_cluster.param.yaml
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_launch/autoware_launch/config/perception/object_recognition/detection/clustering/euclidean_cluster.param.yaml
@@ -1,0 +1,6 @@
+/**:
+  ros__parameters:
+    max_cluster_size: 1000
+    min_cluster_size: 10
+    tolerance: 0.7
+    use_height: false

--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_launch/autoware_launch/config/perception/object_recognition/detection/clustering/outlier.param.yaml
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_launch/autoware_launch/config/perception/object_recognition/detection/clustering/outlier.param.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    input_frame: base_link
+    output_frame: base_link
+    voxel_size_x: 0.3
+    voxel_size_y: 0.3
+    voxel_size_z: 100.0
+    voxel_points_threshold: 3

--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_launch/autoware_launch/config/perception/object_recognition/detection/clustering/voxel_grid.param.yaml
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_launch/autoware_launch/config/perception/object_recognition/detection/clustering/voxel_grid.param.yaml
@@ -1,0 +1,7 @@
+/**:
+  ros__parameters:
+    input_frame: base_link
+    output_frame: base_link
+    voxel_size_x: 0.15
+    voxel_size_y: 0.15
+    voxel_size_z: 0.15

--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_launch/autoware_launch/config/perception/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.param.yaml
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_launch/autoware_launch/config/perception/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.param.yaml
@@ -1,0 +1,15 @@
+/**:
+  ros__parameters:
+    tolerance: 0.7
+    voxel_leaf_size: 0.3
+    min_points_number_per_voxel: 1
+    min_cluster_size: 10
+    max_cluster_size: 3000
+    use_height: false
+    input_frame: "base_link"
+    max_x: 70.0
+    min_x: -70.0
+    max_y: 70.0
+    min_y: -70.0
+    max_z: 4.5
+    min_z: -4.5

--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_universe_launch/tier4_perception_launch/launch/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.launch.py
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_universe_launch/tier4_perception_launch/launch/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.launch.py
@@ -1,0 +1,244 @@
+# Copyright 2020 Tier IV, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import launch
+from launch.actions import DeclareLaunchArgument
+from launch.actions import OpaqueFunction
+from launch.conditions import IfCondition
+from launch.conditions import UnlessCondition
+from launch.substitutions import AnonName
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import LoadComposableNodes
+from launch_ros.descriptions import ComposableNode
+from launch_ros.substitutions import FindPackageShare
+import yaml
+
+
+def launch_setup(context, *args, **kwargs):
+    # https://github.com/ros2/launch_ros/issues/156
+    def load_composable_node_param(param_path):
+        with open(LaunchConfiguration(param_path).perform(context), "r") as f:
+            return yaml.safe_load(f)["/**"]["ros__parameters"]
+
+    ns = ""
+    pkg = "euclidean_cluster"
+
+    # set compare map filter as a component
+    compare_map_filter_component = ComposableNode(
+        package="compare_map_segmentation",
+        namespace=ns,
+        plugin="compare_map_segmentation::VoxelBasedCompareMapFilterComponent",
+        name=AnonName("compare_map_filter"),
+        remappings=[
+            ("input", LaunchConfiguration("input_pointcloud")),
+            ("map", LaunchConfiguration("input_map")),
+            ("output", "map_filter/pointcloud"),
+        ],
+        parameters=[load_composable_node_param("compare_map_param_path")],
+    )
+
+    # separate range of poincloud when map_filter used
+    use_map_short_range_crop_box_filter_component = ComposableNode(
+        package="pointcloud_preprocessor",
+        namespace=ns,
+        plugin="pointcloud_preprocessor::CropBoxFilterComponent",
+        name="short_distance_crop_box_range",
+        remappings=[
+            ("input", "map_filter/pointcloud"),
+            ("output", "short_range/pointcloud"),
+        ],
+        parameters=[
+            load_composable_node_param("voxel_grid_based_euclidean_param_path"),
+            {
+                "negative": False,
+            },
+        ],
+    )
+
+    use_map_long_range_crop_box_filter_component = ComposableNode(
+        package="pointcloud_preprocessor",
+        namespace=ns,
+        plugin="pointcloud_preprocessor::CropBoxFilterComponent",
+        name="long_distance_crop_box_range",
+        remappings=[
+            ("input", LaunchConfiguration("input_pointcloud")),
+            ("output", "long_range/pointcloud"),
+        ],
+        parameters=[
+            load_composable_node_param("voxel_grid_based_euclidean_param_path"),
+            {
+                "negative": True,
+            },
+        ],
+    )
+
+    # disuse_map_voxel_grid_filter
+    disuse_map_short_range_crop_box_filter_component = ComposableNode(
+        package="pointcloud_preprocessor",
+        namespace=ns,
+        plugin="pointcloud_preprocessor::CropBoxFilterComponent",
+        name="short_distance_crop_box_range",
+        remappings=[
+            ("input", LaunchConfiguration("input_pointcloud")),
+            ("output", "short_range/pointcloud"),
+        ],
+        parameters=[
+            load_composable_node_param("voxel_grid_based_euclidean_param_path"),
+            {
+                "negative": False,
+            },
+        ],
+    )
+
+    disuse_map_long_range_crop_box_filter_component = ComposableNode(
+        package="pointcloud_preprocessor",
+        namespace=ns,
+        plugin="pointcloud_preprocessor::CropBoxFilterComponent",
+        name="long_distance_crop_box_range",
+        remappings=[
+            ("input", LaunchConfiguration("input_pointcloud")),
+            ("output", "long_range/pointcloud"),
+        ],
+        parameters=[
+            load_composable_node_param("voxel_grid_based_euclidean_param_path"),
+            {
+                "negative": True,
+            },
+        ],
+    )
+
+    # set voxel grid filter as a component
+    voxel_grid_filter_component = ComposableNode(
+        package="pointcloud_preprocessor",
+        namespace=ns,
+        plugin="pointcloud_preprocessor::ApproximateDownsampleFilterComponent",
+        name=AnonName("voxel_grid_filter"),
+        remappings=[
+            ("input", "short_range/pointcloud"),
+            ("output", "downsampled/short_range/pointcloud"),
+        ],
+        parameters=[load_composable_node_param("voxel_grid_param_path")],
+    )
+
+    # set outlier filter as a component
+    outlier_filter_component = ComposableNode(
+        package="pointcloud_preprocessor",
+        namespace=ns,
+        plugin="pointcloud_preprocessor::VoxelGridOutlierFilterComponent",
+        name="outlier_filter",
+        remappings=[
+            ("input", "downsampled/short_range/pointcloud"),
+            ("output", "outlier_filter/pointcloud"),
+        ],
+        parameters=[load_composable_node_param("outlier_param_path")],
+    )
+
+    # concat with-outlier pointcloud and without-outlier pcl
+    downsample_concat_component = ComposableNode(
+        package="pointcloud_preprocessor",
+        namespace=ns,
+        plugin="pointcloud_preprocessor::PointCloudConcatenateDataSynchronizerComponent",
+        name="concat_downsampled_pcl",
+        remappings=[("output", "downsampled/concatenated/pointcloud")],
+        parameters=[
+            {
+                "input_topics": ["long_range/pointcloud", "outlier_filter/pointcloud"],
+                "output_frame": "base_link",
+            }
+        ],
+        extra_arguments=[{"use_intra_process_comms": True}],
+    )
+
+    # set euclidean cluster as a component
+    euclidean_cluster_component = ComposableNode(
+        package=pkg,
+        namespace=ns,
+        plugin="euclidean_cluster::VoxelGridBasedEuclideanClusterNode",
+        name="euclidean_cluster",
+        remappings=[
+            ("input", "downsampled/concatenated/pointcloud"),
+            ("output", LaunchConfiguration("output_clusters")),
+        ],
+        parameters=[load_composable_node_param("voxel_grid_based_euclidean_param_path")],
+    )
+
+    container = ComposableNodeContainer(
+        name="euclidean_cluster_container",
+        package="rclcpp_components",
+        namespace=ns,
+        executable="component_container",
+        composable_node_descriptions=[
+            voxel_grid_filter_component,
+            outlier_filter_component,
+            downsample_concat_component,
+            euclidean_cluster_component,
+        ],
+        output="screen",
+    )
+
+    use_map_loader = LoadComposableNodes(
+        composable_node_descriptions=[
+            compare_map_filter_component,
+            use_map_short_range_crop_box_filter_component,
+            use_map_long_range_crop_box_filter_component,
+        ],
+        target_container=container,
+        condition=IfCondition(LaunchConfiguration("use_pointcloud_map")),
+    )
+
+    disuse_map_loader = LoadComposableNodes(
+        composable_node_descriptions=[
+            disuse_map_short_range_crop_box_filter_component,
+            disuse_map_long_range_crop_box_filter_component,
+        ],
+        target_container=container,
+        condition=UnlessCondition(LaunchConfiguration("use_pointcloud_map")),
+    )
+
+    return [container, use_map_loader, disuse_map_loader]
+
+
+def generate_launch_description():
+    def add_launch_arg(name: str, default_value=None):
+        return DeclareLaunchArgument(name, default_value=default_value)
+
+    return launch.LaunchDescription(
+        [
+            add_launch_arg("input_pointcloud", "/perception/obstacle_segmentation/pointcloud"),
+            add_launch_arg("input_map", "/map/pointcloud_map"),
+            add_launch_arg("output_clusters", "clusters"),
+            add_launch_arg("use_pointcloud_map", "false"),
+            add_launch_arg(
+                "voxel_grid_param_path",
+                [FindPackageShare("euclidean_cluster"), "/config/voxel_grid.param.yaml"],
+            ),
+            add_launch_arg(
+                "outlier_param_path",
+                [FindPackageShare("euclidean_cluster"), "/config/outlier.param.yaml"],
+            ),
+            add_launch_arg(
+                "compare_map_param_path",
+                [FindPackageShare("euclidean_cluster"), "/config/compare_map.param.yaml"],
+            ),
+            add_launch_arg(
+                "voxel_grid_based_euclidean_param_path",
+                [
+                    FindPackageShare("euclidean_cluster"),
+                    "/config/voxel_grid_based_euclidean_cluster.param.yaml",
+                ],
+            ),
+            OpaqueFunction(function=launch_setup),
+        ]
+    )

--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_universe_launch/tier4_perception_launch/launch/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.launch.xml
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_universe_launch/tier4_perception_launch/launch/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.launch.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="input_pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
+  <arg name="input_map" default="/map/pointcloud_map"/>
+  <arg name="output_clusters" default="clusters"/>
+  <arg name="use_pointcloud_map" default="false"/>
+  <arg name="voxel_grid_param_path" default="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/clustering/voxel_grid.param.yaml"/>
+  <arg name="compare_map_param_path" default="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/clustering/compare_map.param.yaml"/>
+  <arg name="outlier_param_path" default="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/clustering/outlier.param.yaml"/>
+  <arg name="voxel_grid_based_euclidean_param_path" default="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.param.yaml"/>
+
+  <include file="$(find-pkg-share euclidean_cluster)/launch/voxel_grid_based_euclidean_cluster.launch.py">
+    <arg name="input_pointcloud" value="$(var input_pointcloud)"/>
+    <arg name="input_map" value="$(var input_map)"/>
+    <arg name="output_clusters" value="$(var output_clusters)"/>
+    <arg name="use_pointcloud_map" value="$(var use_pointcloud_map)"/>
+    <arg name="voxel_grid_param_path" value="$(var voxel_grid_param_path)"/>
+    <arg name="compare_map_param_path" value="$(var compare_map_param_path)"/>
+    <arg name="outlier_param_path" value="$(var outlier_param_path)"/>
+    <arg name="voxel_grid_based_euclidean_param_path" value="$(var voxel_grid_based_euclidean_param_path)"/>
+  </include>
+</launch>

--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_universe_launch/tier4_perception_launch/launch/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.launch.xml
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_universe_launch/tier4_perception_launch/launch/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.launch.xml
@@ -9,7 +9,7 @@
   <arg name="outlier_param_path" default="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/clustering/outlier.param.yaml"/>
   <arg name="voxel_grid_based_euclidean_param_path" default="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.param.yaml"/>
 
-  <include file="$(find-pkg-share euclidean_cluster)/launch/voxel_grid_based_euclidean_cluster.launch.py">
+  <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.launch.py">
     <arg name="input_pointcloud" value="$(var input_pointcloud)"/>
     <arg name="input_map" value="$(var input_map)"/>
     <arg name="output_clusters" value="$(var output_clusters)"/>

--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_universe_launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_universe_launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
@@ -29,7 +29,7 @@
     <let name="clustering/input/pointcloud" value="/perception/object_recognition/detection/pointcloud_map_filtered/pointcloud" if="$(var use_pointcloud_map)"/>
     <let name="clustering/input/pointcloud" value="$(var input/obstacle_segmentation/pointcloud)" unless="$(var use_pointcloud_map)"/>
     <group>
-      <include file="$(find-pkg-share euclidean_cluster)/launch/voxel_grid_based_euclidean_cluster.launch.xml">
+      <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.launch.xml">
         <arg name="input_pointcloud" value="$(var clustering/input/pointcloud)"/>
         <arg name="output_clusters" value="clusters"/>
         <arg name="use_pointcloud_map" value="false"/>

--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_universe_launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_universe_launch/tier4_perception_launch/launch/perception.launch.xml
@@ -35,7 +35,7 @@
   <arg name="camera_info7" default="/sensing/camera/camera7/camera_info"/>
   <arg name="image_number" default="6" description="choose image raw number(0-7)"/>
   <arg name="use_vector_map" default="true" description="use vector map in prediction"/>
-  <arg name="use_pointcloud_map" default="true" description="use pointcloud map in detection"/>
+  <arg name="use_pointcloud_map" default="false" description="use pointcloud map in detection"/>
   <arg name="use_object_filter" default="true" description="use object filter"/>
   <arg
     name="use_empty_dynamic_object_publisher"


### PR DESCRIPTION
## Problem

- The input pointcloud for the euclidean_cluster node was downsampled too much; therefore, the clustering process was not working properly.
- The launch files and configs for clustering were not included in the `tier4_perception_launch` package.

## Differences in the pointcloud before and after downsampling

The pointcloud from the downsampled topic `/perception/object_recognition/detection/clustering/downsampled/concatenated/pointcloud` is visualized below. This topic was originally the input for the euclidean_cluster node.

![Screenshot from 2023-07-31 11-19-39](https://github.com/AutomotiveAIChallenge/aichallenge2023-sim/assets/5180742/b865f81f-3cb3-46ca-b61f-b6d8368d106b)

Meanwhile, the pointcloud before the downsampling steps is in the `/perception/obstacle_segementation/pointcloud` topic, and is visualized below. This pointcloud is more suitable for inputting into the euclidean_cluster node.

![Screenshot from 2023-07-31 11-19-03](https://github.com/AutomotiveAIChallenge/aichallenge2023-sim/assets/5180742/4f88ca4b-56b9-49c9-80f1-1686a2c961b4)

## Solution

- Removed the several downsampling nodes before the euclidean_clustering, and made the input of the euclidean_cluster node the `/perception/obstacle_segementation/pointcloud` topic.
- Included the clustering launch files and config files in the `tier4_perception_launch` package.

## Improved Detection Results

After the changes in this PR, more obstacles were detected in general, including ones that were far away.

![Screenshot from 2023-07-31 11-54-53](https://github.com/AutomotiveAIChallenge/aichallenge2023-sim/assets/5180742/7a325db5-2e5f-4b13-8718-726b4deb557d)
