### PR TITLE
fix: not use local host only

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,6 @@ FROM ghcr.io/automotiveaichallenge/aichallenge2023-sim/autoware-universe-cuda:v1
 
 RUN rm -rf /autoware/install/tier4_*_launch
 
-ENV ROS_LOCALHOST_ONLY 1
+ENV ROS_LOCALHOST_ONLY 0
 ENV RMW_IMPLEMENTATION rmw_cyclonedds_cpp
 ENV export RCUTILS_COLORIZED_OUTPUT 1


### PR DESCRIPTION
fix: not use local host only to run AWSIM with different container
this will fix https://aichallenge2023-integ.slack.com/archives/C05CJ9BJ96Y/p1691225919536809
reference: https://github.com/AutomotiveAIChallenge/aichallenge2023-sim/blob/6f6b85349ccd986587b90718d9bf94f9f5dc6401/docker/evaluation/main.bash#L7
![image](https://github.com/AutomotiveAIChallenge/aichallenge2023-sim/assets/65527974/b6995446-cf0d-4d2c-be52-8253b1a9783f)
