### PR TITLE
doc: remove register banner from all pages

### DIFF
--- a/documentation/docfx_project/index.md
+++ b/documentation/docfx_project/index.md
@@ -2,11 +2,11 @@
 
 <br>
 
-> [!REGISTER]
+<!-- > [!REGISTER]
 > こちらから参加登録!
 > [https://www.jsae.or.jp/jaaic/en/index.php](https://www.jsae.or.jp/jaaic/en/index.php)
 
-<br>
+<br> -->
 
 ![AIchallenge2023](./images/top/aichallenge2023.png) 
 

--- a/documentation/docfx_project/intro/index.md
+++ b/documentation/docfx_project/intro/index.md
@@ -2,11 +2,11 @@
 
 <br>
 
-> [!REGISTER]
+<!-- > [!REGISTER]
 > こちらから参加登録!
 > [https://www.jsae.or.jp/jaaic/en/index.php](https://www.jsae.or.jp/jaaic/en/index.php)
 
-<br>
+<br> -->
 
 ## Introduction
 &emsp;昨年度行った、自動運転AIチャレンジ2022シミュレーション大会と同様に、自動運転AIチャレンジ2023インテグレーション大会の予選大会では自動運転ソフトウェアAutoware.universeと自動運転シミュレータAWSIMを使用します。[Setupページ](../setup/index.html)記載の手順に沿って環境を構築し、大会へご参加ください。

--- a/documentation/docfx_project/online/index.md
+++ b/documentation/docfx_project/online/index.md
@@ -1,11 +1,11 @@
 # Online Environment
 <br>
 
-> [!REGISTER]
+<!-- > [!REGISTER]
 > こちらから参加登録!
 > [https://www.jsae.or.jp/jaaic/en/index.php](https://www.jsae.or.jp/jaaic/en/index.php)
 
-<br>
+<br> -->
 
  &emsp;本大会での採点は、シミュレータ・自動採点機能を備えたオンライン環境で行われます。  
  &emsp;下記手順を参考に、作成していただいたパッケージ群をオンライン環境にアップロードしてください。アップロード完了後、オンライン環境にてシミュレーションが開始され、結果が提示されます。

--- a/documentation/docfx_project/rule/index.md
+++ b/documentation/docfx_project/rule/index.md
@@ -2,11 +2,11 @@
 
 <br>
 
-> [!REGISTER]
+<!-- > [!REGISTER]
 > こちらから参加登録!
 > [https://www.jsae.or.jp/jaaic/en/index.php](https://www.jsae.or.jp/jaaic/en/index.php)
 
-<br>
+<br> -->
 
 &emsp;参加者の皆様が開発した自動運転ソフトウェアを用いて自動運転車両を走行させ、その結果から算出される`距離点`で競い合っていただきます。  
 &emsp;競技の詳細やコースの仕様などについては、下記をご参照ください。

--- a/documentation/docfx_project/setup/index.md
+++ b/documentation/docfx_project/setup/index.md
@@ -2,11 +2,11 @@
 
 <br>
 
-> [!REGISTER]
+<!-- > [!REGISTER]
 > こちらから参加登録!
 > [https://www.jsae.or.jp/jaaic/en/index.php](https://www.jsae.or.jp/jaaic/en/index.php)
 
-<br>
+<br> -->
 
 ## Minimum Hardware Requirements
 本大会で使用していただくPCの動作環境として以下を推奨しております。

--- a/documentation/docfx_project_en/index.md
+++ b/documentation/docfx_project_en/index.md
@@ -2,12 +2,12 @@
 
 <br>
 
-> [!REGISTER]
+<!-- > [!REGISTER]
 > Register from here!
 > [https://www.jsae.or.jp/jaaic/en/index.php](https://www.jsae.or.jp/jaaic/en/index.php)
 
 
-<br>
+<br> -->
 
 ![AIchallenge2023](../images/top/aichallenge2023.png)
 

--- a/documentation/docfx_project_en/intro/index.md
+++ b/documentation/docfx_project_en/intro/index.md
@@ -2,11 +2,11 @@
 
 <br>
 
-> [!REGISTER]
+<!-- > [!REGISTER]
 > Register from here!
 > [https://www.jsae.or.jp/jaaic/en/index.php](https://www.jsae.or.jp/jaaic/en/index.php)
 
-<br>
+<br> -->
 
 ## Introduction
 As in the Automated AI Challenge 2022 simulation competition held last year, the qualifying competition for the Automated AI Challenge 2023 Integration Competition will use the Autoware.universe automated driving software and the AWSIM automated driving simulator. The [Setup page](../setup) and participate in the competition.

--- a/documentation/docfx_project_en/local/index.md
+++ b/documentation/docfx_project_en/local/index.md
@@ -2,11 +2,11 @@
 
 <br>
 
-> [!REGISTER]
+<!-- > [!REGISTER]
 > Register from here!
 > [https://www.jsae.or.jp/jaaic/en/index.php](https://www.jsae.or.jp/jaaic/en/index.php)
 
-<br>
+<br> -->
 
  &emsp; Participants will be asked to create a ROS2 package to carry out the scenario, and the following ROS2 package is provided in aichallenge2023-sim/docker/aichallenge/aichallenge_ws/src as sample code to serve as a base for this in this repository The following ROS2 package is provided.  
  &emsp; Please place the ROS2 package you created under aichallenge_ws/src/aichallenge_submit and follow the steps below to build and run it.

--- a/documentation/docfx_project_en/online/index.md
+++ b/documentation/docfx_project_en/online/index.md
@@ -1,11 +1,11 @@
 # Online Environment
 <br>
 
-> [!REGISTER]
+<!-- > [!REGISTER]
 > Register from here!
 > [https://www.jsae.or.jp/jaaic/en/index.php](https://www.jsae.or.jp/jaaic/en/index.php)
 
-<br>
+<br> -->
 
  &emsp; In this competition, scoring will be conducted in an online environment equipped with simulators and automatic grading features.   
  &emsp; Follow the steps below to upload the package you have created to the online environment. After the upload is complete, the simulation will start in the online environment, and the results will be presented.

--- a/documentation/docfx_project_en/rule/index.md
+++ b/documentation/docfx_project_en/rule/index.md
@@ -2,12 +2,12 @@
 
 <br>
 
-> [!REGISTER]
+<!-- > [!REGISTER]
 > Register from here!
 > [https://www.jsae.or.jp/jaaic/en/index.php](https://www.jsae.or.jp/jaaic/en/index.php)
 
 
-<br>
+<br> -->
 
 &emsp;Participants will drive an automated vehicle using the automated driving software they have developed, and compete in terms of `distance points` calculated from the results.  
 For details of the competition and course specifications, please refer to the following.


### PR DESCRIPTION
Since the application period for new participants for this year's AI Challenge has ended, all "Register Now (こちらから参加登録)" banners have been removed from the top of the pages.

In the source code, they have been commented out so we can use them in the future as well.