### PR TITLE
fix: disable estimation and add rtc controller

### DIFF
--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/aichallenge_submit_launch/launch/autoware_mini_awsim.launch.xml
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/aichallenge_submit_launch/launch/autoware_mini_awsim.launch.xml
@@ -275,7 +275,7 @@
         <remap from="ekf_twist_with_covariance" to="twist_with_covariance"/>
         <param name="pose_frame_id" value="map"/>
         <param name="show_debug_info" value="false"/>
-        <param name="enable_yaw_bias_estimation" value="true"/>
+        <param name="enable_yaw_bias_estimation" value="false"/>
         <param name="predict_frequency" value="50.0"/>
         <param name="tf_rate" value="50.0"/>
         <param name="extend_state_step" value="50"/>
@@ -497,6 +497,10 @@
         <group>
           <push-ros-namespace namespace="behavior_planning"/>
 
+          <include file="$(find-pkg-share rtc_auto_mode_manager)/launch/rtc_auto_mode_manager.launch.xml">
+            <arg name="param_path" value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/rtc_auto_mode_manager/rtc_auto_mode_manager.param.yaml"/>
+          </include>
+
           <!-- behavior_planning_container -->
           <node_container pkg="rclcpp_components" exec="component_container" name="behavior_planning_container" namespace="">
 
@@ -638,6 +642,12 @@
   <group>
     <!-- default_ad_api -->
     <include file="$(find-pkg-share default_ad_api)/launch/default_ad_api.launch.py" />
+
+    <!-- RTC controller -->
+    <push-ros-namespace namespace="autoware_api/external/rtc_controller"/>
+    <node_container pkg="rclcpp_components" exec="component_container_mt" name="container" namespace="" ros_args="--log-level autoware_api.external.rtc_controller.container:=warn">
+      <composable_node pkg="autoware_iv_external_api_adaptor" plugin="external_api::RTCController" name="node"/>
+    </node_container>
 
     <!-- ad_api_adaptors -->
     <include file="$(find-pkg-share ad_api_adaptors)/launch/rviz_adaptors.launch.xml" />


### PR DESCRIPTION
feat:  add rtc controller to approve avoidance

![Screenshot from 2023-08-18 11-17-16](https://github.com/AutomotiveAIChallenge/aichallenge2023-sim/assets/65527974/fd6defee-92f2-42bb-a676-0a785228835e)
