### PR TITLE
fix: use center point tiny model to consider wrong centerpoint config

### DIFF
--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_universe_launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_universe_launch/tier4_perception_launch/launch/perception.launch.xml
@@ -9,7 +9,7 @@
   <arg name="obstacle_segmentation_ground_segmentation_elevation_map_param_path"/>
 
   <!-- centerpoint model configs -->
-  <arg name="centerpoint_model_name" default="centerpoint" description="options: `centerpoint` or `centerpoint_tiny`"/>
+  <arg name="centerpoint_model_name" default="centerpoint_tiny" description="options: `centerpoint` or `centerpoint_tiny`"/>
   <arg name="centerpoint_model_path" default="$(find-pkg-share lidar_centerpoint)/data"/>
   <arg name="centerpoint_model_param_path" default="$(find-pkg-share lidar_centerpoint)/config/$(var centerpoint_model_name).param.yaml"/>
 


### PR DESCRIPTION
https://github.com/autowarefoundation/autoware.universe/pull/4701

- center point はクラスラベルの修正が必要であったが、autoware.universe内のファイルを参照しており、docker imageごと更新が必要なため、現状のcenter pointの不適切なconfigよりはデフォルトのcenter pointのモデルをtinyにするほうが良いという結論になり、この修正を加える。