### PR TITLE
doc(teams): add teams page and update topbar

### DIFF
--- a/documentation/docfx_project/docfx.json
+++ b/documentation/docfx_project/docfx.json
@@ -64,6 +64,12 @@
       },
       {
         "files": [
+          "teams/toc.yml",
+          "teams/index.md"
+        ]
+      },
+      {
+        "files": [
           "FAQ/toc.yml",
           "FAQ/index.md"
         ]

--- a/documentation/docfx_project/teams/index.md
+++ b/documentation/docfx_project/teams/index.md
@@ -1,0 +1,12 @@
+# Teams
+
+<br>
+
+本ページでは、予選大会に参加したチームの紹介を行います．
+
+<br>
+
+| Team Name | Photo  | Message from the team |
+| :-----: | :-----: | :----- |
+| Team A | <img src="https://placehold.jp/300x200.png" alt="Team Photo" width="100%"> | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin consectetur velit ac nisi condimentum fringilla. Sed ac rhoncus dui. In hendrerit sapien ut magna faucibus, et facilisis justo scelerisque. Cras ut egestas metus, sit amet faucibus nisl. Nulla non magna mattis, viverra eros at, porttitor tortor. Curabitur rutrum lacinia vehicula. Vestibulum rutrum orci a arcu iaculis venenatis. Nulla ornare tellus nec eleifend venenatis. |
+| Team B | <img src="https://placehold.jp/300x200.png" alt="Team Photo" width="100%"> | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin consectetur velit ac nisi condimentum fringilla. Sed ac rhoncus dui. In hendrerit sapien ut magna faucibus, et facilisis justo scelerisque. Cras ut egestas metus, sit amet faucibus nisl. Nulla non magna mattis, viverra eros at, porttitor tortor. Curabitur rutrum lacinia vehicula. Vestibulum rutrum orci a arcu iaculis venenatis. Nulla ornare tellus nec eleifend venenatis. |

--- a/documentation/docfx_project/teams/toc.yml
+++ b/documentation/docfx_project/teams/toc.yml
@@ -1,0 +1,3 @@
+- name: Teams
+  href: index.html
+  homepage: teams/index.html

--- a/documentation/docfx_project/toc.yml
+++ b/documentation/docfx_project/toc.yml
@@ -2,18 +2,26 @@
   href: index.html
 - name: Introduction
   href: intro/index.html
-- name: Setup
-  href: setup/index.html
-- name: Rule
-  href: rule/index.html
-- name: LocalEnvironment
-  href: local/index.html
-- name: OnlineEnvironment
-  href: online/index.html
+- name: Preliminaries
+  dropdown: true
+  items:
+  - name: Setup
+    href: setup/index.html
+  - name: Rule
+    href: rule/index.html
+  - name: LocalEnvironment
+    href: local/index.html
+  - name: OnlineEnvironment
+    href: online/index.html
+- name: Finals
+  dropdown: true
+  items:
+  - name: Operation
+    href: operation/index.html
+- name: Teams
+  href: teams/index.html
 - name: Customizing Autoware
   href: customize/index.html
-- name: Operation
-  href: operation/index.html
 - name: FAQ
   href: FAQ/index.html
 - name: Other

--- a/documentation/docfx_project_en/docfx.json
+++ b/documentation/docfx_project_en/docfx.json
@@ -58,6 +58,18 @@
       },
       {
         "files": [
+          "operation/toc.yml",
+          "operation/index.md"
+        ]
+      },
+      {
+        "files": [
+          "teams/toc.yml",
+          "teams/index.md"
+        ]
+      },
+      {
+        "files": [
           "FAQ/toc.yml",
           "FAQ/index.md"
         ]

--- a/documentation/docfx_project_en/teams/index.md
+++ b/documentation/docfx_project_en/teams/index.md
@@ -1,0 +1,12 @@
+# Teams
+
+<br>
+
+These are the teams who participated in the preliminary round of this year's Japan Automotive AI Challenge 2023 Integration Competition.
+
+<br>
+
+| Team Name | Photo  | Message from the team |
+| :-----: | :-----: | :----- |
+| Team A | <img src="https://placehold.jp/300x200.png" alt="Team Photo" width="100%"> | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin consectetur velit ac nisi condimentum fringilla. Sed ac rhoncus dui. In hendrerit sapien ut magna faucibus, et facilisis justo scelerisque. Cras ut egestas metus, sit amet faucibus nisl. Nulla non magna mattis, viverra eros at, porttitor tortor. Curabitur rutrum lacinia vehicula. Vestibulum rutrum orci a arcu iaculis venenatis. Nulla ornare tellus nec eleifend venenatis. |
+| Team B | <img src="https://placehold.jp/300x200.png" alt="Team Photo" width="100%"> | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin consectetur velit ac nisi condimentum fringilla. Sed ac rhoncus dui. In hendrerit sapien ut magna faucibus, et facilisis justo scelerisque. Cras ut egestas metus, sit amet faucibus nisl. Nulla non magna mattis, viverra eros at, porttitor tortor. Curabitur rutrum lacinia vehicula. Vestibulum rutrum orci a arcu iaculis venenatis. Nulla ornare tellus nec eleifend venenatis. |

--- a/documentation/docfx_project_en/teams/toc.yml
+++ b/documentation/docfx_project_en/teams/toc.yml
@@ -1,0 +1,3 @@
+- name: Teams
+  href: index.html
+  homepage: teams/index.html

--- a/documentation/docfx_project_en/toc.yml
+++ b/documentation/docfx_project_en/toc.yml
@@ -2,14 +2,24 @@
   href: index.html
 - name: Introduction
   href: intro/index.html
-- name: Setup
-  href: setup/index.html
-- name: Rule
-  href: rule/index.html
-- name: LocalEnvironment
-  href: local/index.html
-- name: OnlineEnvironment
-  href: online/index.html
+- name: Preliminaries
+  dropdown: true
+  items:
+  - name: Setup
+    href: setup/index.html
+  - name: Rule
+    href: rule/index.html
+  - name: LocalEnvironment
+    href: local/index.html
+  - name: OnlineEnvironment
+    href: online/index.html
+- name: Finals
+  dropdown: true
+  items:
+  - name: Operation
+    href: operation/index.html
+- name: Teams
+  href: teams/index.html
 - name: Customizing Autoware
   href: customize/index.html
 - name: FAQ


### PR DESCRIPTION
- Add "Teams" page for both Japanese and English. Add filler text.
  - ![image](https://github.com/AutomotiveAIChallenge/aichallenge2023-sim/assets/5180742/7d2676a0-3829-450d-b333-c510c4daf2f2)
- Update top menu bar to show dropdown menus for "Preliminaries" and "Finals".
  - ![Screenshot from 2023-09-08 12-40-52](https://github.com/AutomotiveAIChallenge/aichallenge2023-sim/assets/5180742/f1e9e4ff-084d-4930-8604-a1d7b5059d93)
