### PR TITLE
doc(teams): link EN version of teams doc to JP

### DIFF
--- a/documentation/docfx_project_en/toc.yml
+++ b/documentation/docfx_project_en/toc.yml
@@ -19,7 +19,7 @@
   - name: Operation
     href: operation/index.html
 - name: Teams
-  href: teams/index.html
+  href: ../teams/index.html
 - name: Customizing Autoware
   href: customize/index.html
 - name: FAQ


### PR DESCRIPTION
- 英語版のチーム紹介ページから日本語版のチーム紹介ページに飛ぶようにしました．